### PR TITLE
fix: Update open api by removing recipientCode from required

### DIFF
--- a/openApi/dashboard-api-docs.json
+++ b/openApi/dashboard-api-docs.json
@@ -3879,7 +3879,6 @@
           "institutionType",
           "mailAddress",
           "name",
-          "recipientCode",
           "vatNumber",
           "zipCode"
         ],

--- a/src/model/OnboardingRequestResource.ts
+++ b/src/model/OnboardingRequestResource.ts
@@ -24,7 +24,7 @@ type InstitutionInfo = {
   mailAddress: string;
   name: string;
   pspData: PspData;
-  recipientCode: string;
+  recipientCode?: string;
   vatNumber: string;
 };
 

--- a/src/model/OnboardingRequestResource.ts
+++ b/src/model/OnboardingRequestResource.ts
@@ -16,14 +16,14 @@ type UserInfo = {
 
 type InstitutionInfo = {
   address: string;
-  dpoData: DpoData;
+  dpoData?: DpoData;
   fiscalCode: string;
   id: string;
   institutionType: string;
   zipCode: string;
   mailAddress: string;
   name: string;
-  pspData: PspData;
+  pspData?: PspData;
   recipientCode?: string;
   vatNumber: string;
 };

--- a/src/services/__mocks__/dashboardRequestService.ts
+++ b/src/services/__mocks__/dashboardRequestService.ts
@@ -58,19 +58,6 @@ export const mockedOnboardingRequests: Array<OnboardingRequestResource> = [
       mailAddress: 'comune.milano@pecemail.com',
       fiscalCode: '76765454321',
       vatNumber: '22233344456',
-      pspData: {
-        vatNumberGroup: true,
-        businessRegisterNumber: '22222222222',
-        legalRegisterName: 'DummySubscribe02',
-        legalRegisterNumber: '41',
-        abiCode: '22334',
-      },
-      recipientCode: 'DummyRecipientCode02',
-      dpoData: {
-        address: 'Via Lombardia, 5',
-        pec: 'dpo02@pecdpo.com',
-        email: 'dpo02@dpo.com',
-      },
       institutionType: 'PT',
     },
     admins: [


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Update open api by removing recipientCode from required
Updated the mocked service
<!--- Describe your changes in detail -->

#### Motivation and Context
For PT the recipientCode is not required to compile during onboarding so the field could be missing.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Tested locally 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.