### PR TITLE
fix: update openApi manager and recipient code no longer required for PT

### DIFF
--- a/openApi/dashboard-api-docs.json
+++ b/openApi/dashboard-api-docs.json
@@ -3879,7 +3879,6 @@
           "institutionType",
           "mailAddress",
           "name",
-          "recipientCode",
           "vatNumber",
           "zipCode"
         ],

--- a/openApi/dashboard-api-docs.json
+++ b/openApi/dashboard-api-docs.json
@@ -4173,7 +4173,7 @@
       },
       "OnboardingRequestResource": {
         "title": "OnboardingRequestResource",
-        "required": ["institutionInfo", "manager", "status"],
+        "required": ["institutionInfo", "status"],
         "type": "object",
         "properties": {
           "admins": {

--- a/src/model/OnboardingRequestResource.ts
+++ b/src/model/OnboardingRequestResource.ts
@@ -16,15 +16,15 @@ type UserInfo = {
 
 type InstitutionInfo = {
   address: string;
-  dpoData: DpoData;
+  dpoData?: DpoData;
   fiscalCode: string;
   id: string;
   institutionType: string;
   zipCode: string;
   mailAddress: string;
   name: string;
-  pspData: PspData;
-  recipientCode: string;
+  pspData?: PspData;
+  recipientCode?: string;
   vatNumber: string;
 };
 

--- a/src/model/OnboardingRequestResource.ts
+++ b/src/model/OnboardingRequestResource.ts
@@ -2,7 +2,7 @@ export type OnboardingRequestResource = {
   tokenId: string;
   admins?: Array<UserInfo>;
   institutionInfo: InstitutionInfo;
-  manager: UserInfo;
+  manager?: UserInfo;
   status: 'ACTIVE' | 'DELETED' | 'PENDING' | 'REJECTED' | 'SUSPENDED' | 'TOBEVALIDATED';
 };
 

--- a/src/pages/dashboardRequest/components/DashboardRequestFields.tsx
+++ b/src/pages/dashboardRequest/components/DashboardRequestFields.tsx
@@ -300,7 +300,7 @@ export default function DashboardRequestFields({ onboardingRequestData, isPSP }:
           </Grid>
         </Grid>
       </Paper>
-      {!isTechPartner && (
+      {!isTechPartner && onboardingRequestData?.manager && (
         <Paper elevation={8} sx={{ borderRadius: theme.spacing(2) }}>
           <Grid container sx={{ marginY: 4, marginX: 4 }}>
             <Grid item xs={12}>
@@ -327,7 +327,7 @@ export default function DashboardRequestFields({ onboardingRequestData, isPSP }:
                   </Grid>
                   <Grid item xs={9} display="flex" alignItems={'center'}>
                     <Typography sx={{ fontSize: 'fontSize', fontWeight: 'fontWeightMedium' }}>
-                      {onboardingRequestData?.manager.name}
+                      {onboardingRequestData.manager.name}
                     </Typography>
                   </Grid>
                 </Grid>
@@ -343,7 +343,7 @@ export default function DashboardRequestFields({ onboardingRequestData, isPSP }:
                   </Grid>
                   <Grid item xs={9} display="flex" alignItems={'center'}>
                     <Typography sx={{ fontSize: 'fontSize', fontWeight: 'fontWeightMedium' }}>
-                      {onboardingRequestData?.manager.surname}
+                      {onboardingRequestData.manager.surname}
                     </Typography>
                   </Grid>
                 </Grid>
@@ -359,7 +359,7 @@ export default function DashboardRequestFields({ onboardingRequestData, isPSP }:
                   </Grid>
                   <Grid item xs={9} display="flex" alignItems={'center'}>
                     <Typography sx={{ fontSize: 'fontSize', fontWeight: 'fontWeightMedium' }}>
-                      {onboardingRequestData?.manager.fiscalCode}
+                      {onboardingRequestData.manager.fiscalCode}
                     </Typography>
                   </Grid>
                 </Grid>
@@ -375,7 +375,7 @@ export default function DashboardRequestFields({ onboardingRequestData, isPSP }:
                   </Grid>
                   <Grid item xs={9} display="flex" alignItems={'center'}>
                     <Typography sx={{ fontSize: 'fontSize', fontWeight: 'fontWeightMedium' }}>
-                      {onboardingRequestData?.manager.email.toLocaleLowerCase()}
+                      {onboardingRequestData.manager.email.toLocaleLowerCase()}
                     </Typography>
                   </Grid>
                 </Grid>

--- a/src/pages/dashboardRequest/components/__tests__/DashboardRequestFields.test.tsx
+++ b/src/pages/dashboardRequest/components/__tests__/DashboardRequestFields.test.tsx
@@ -25,7 +25,7 @@ test('should render component with PSP and group vatNumberGroup should not be vi
   expect(screen.getByText('No')).toBeInTheDocument();
 });
 
-test('should render component with PT and legal rapresentation section should not be visible', async () => {
+test('should render component with PT with empty manager object and legal rapresentation section should not be visible', async () => {
   render(
     <DashboardRequestFields onboardingRequestData={mockedOnboardingRequests[1]} isPSP={false} />
   );

--- a/src/services/__mocks__/dashboardRequestService.ts
+++ b/src/services/__mocks__/dashboardRequestService.ts
@@ -73,13 +73,6 @@ export const mockedOnboardingRequests: Array<OnboardingRequestResource> = [
       },
       institutionType: 'PT',
     },
-    manager: {
-      id: 'Manager02',
-      name: 'Manager02',
-      surname: 'Manager02',
-      fiscalCode: 'MNGMGR22D22B345K',
-      email: 'manager02@manager.com',
-    },
     admins: [
       // Use case with 3 admins
       {

--- a/src/services/__mocks__/dashboardRequestService.ts
+++ b/src/services/__mocks__/dashboardRequestService.ts
@@ -58,19 +58,6 @@ export const mockedOnboardingRequests: Array<OnboardingRequestResource> = [
       mailAddress: 'comune.milano@pecemail.com',
       fiscalCode: '76765454321',
       vatNumber: '22233344456',
-      pspData: {
-        vatNumberGroup: true,
-        businessRegisterNumber: '22222222222',
-        legalRegisterName: 'DummySubscribe02',
-        legalRegisterNumber: '41',
-        abiCode: '22334',
-      },
-      recipientCode: 'DummyRecipientCode02',
-      dpoData: {
-        address: 'Via Lombardia, 5',
-        pec: 'dpo02@pecdpo.com',
-        email: 'dpo02@dpo.com',
-      },
       institutionType: 'PT',
     },
     admins: [


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
The manager object removed from reequired
The recipientCode inside institutionInfo removed from required 
<!--- Describe your changes in detail -->

#### Motivation and Context
For PT there is no manager or recipientCode so they should be removed as required from the openApi
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Tested in dev enviroment
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.