### PR TITLE
[SELC-3981] feat: Auto-closing admin panel card previously opened+opened party data as default

### DIFF
--- a/src/pages/dashboardRequest/components/DashboardRequestFields.tsx
+++ b/src/pages/dashboardRequest/components/DashboardRequestFields.tsx
@@ -10,7 +10,7 @@ import {
 } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { theme } from '@pagopa/mui-italia';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import { productId2ProductTitle } from '@pagopa/selfcare-common-frontend/utils/productId2ProductTitle';
@@ -25,15 +25,20 @@ type Props = {
 export default function DashboardRequestFields({ onboardingRequestData, isPSP }: Props) {
   const { t } = useTranslation();
 
-  const [expanded, setExpanded] = useState<{ [index: string]: boolean }>({});
+  const [expanded, setExpanded] = useState<{ [index: string]: boolean }>({ ['1']: true });
+  const expandedIndexRef = useRef<string>('1');
 
   const isTechPartner = onboardingRequestData?.institutionInfo.institutionType === 'PT';
 
   const handleExpandClick = (index: string) => {
     setExpanded((prevExpanded) => ({
       ...prevExpanded,
+      [expandedIndexRef.current]: !!prevExpanded[index],
       [index]: !prevExpanded[index],
     }));
+
+    // eslint-disable-next-line functional/immutable-data
+    expandedIndexRef.current = index;
   };
 
   const getInstitutionTypeDescription = (institutionType: string) =>


### PR DESCRIPTION

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
Auto-closing admin panel card previously opened and opened party data as default

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
In order to offer the best user experience at admin, the card with party data is opened as default landing in the page and when a card is expanded, the card that was expanded previously automatically closed

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Tested in local environment, the expected cases are all satisfied
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.