### PR TITLE
[SELC-5516] feat: Added button to download the document

### DIFF
--- a/openApi/generated-onboarding/onboarding-swagger20.json
+++ b/openApi/generated-onboarding/onboarding-swagger20.json
@@ -890,6 +890,7 @@
             "enum": [
               "AS",
               "CON",
+              "GPU",
               "GSP",
               "PA",
               "PG",
@@ -1079,10 +1080,7 @@
           "200": {
             "description": "OK",
             "schema": {
-              "additionalProperties": {
-                "type": "boolean"
-              },
-              "type": "object"
+              "$ref": "#/definitions/CheckManagerResponse"
             }
           },
           "400": {
@@ -1208,6 +1206,79 @@
         "description": "The service allows the onboarding of Users",
         "operationId": "onboardingUsingPOST_4",
         "summary": "onboarding"
+      }
+    },
+    "/v1/users/onboarding/aggregator": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/problem+json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "schema": {
+              "$ref": "#/definitions/OnboardingUserDto"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ],
+        "tags": [
+          "user"
+        ],
+        "description": "The service allows the onboarding of Users for aggregators",
+        "operationId": "onboardingAggregatorUsingPOST",
+        "summary": "onboardingAggregator"
       }
     },
     "/v1/users/validate": {
@@ -1450,6 +1521,77 @@
         "summary": "onboarding"
       }
     },
+    "/v2/institutions/company/verify-manager": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json",
+          "application/problem+json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "schema": {
+              "$ref": "#/definitions/VerifyManagerRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/VerifyManagerResponse"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ],
+        "tags": [
+          "institutions"
+        ],
+        "description": "The service allows to verify the legal representative on external registries and retrieve the company name",
+        "operationId": "verifyManagerUsingPOST",
+        "summary": "verifyManager"
+      }
+    },
     "/v2/institutions/onboarding": {
       "post": {
         "consumes": [
@@ -1521,6 +1663,80 @@
         "description": "The service allows the onboarding of Users to a subunit of an Institution",
         "operationId": "onboardingUsingPOST_3",
         "summary": "onboarding"
+      }
+    },
+    "/v2/institutions/onboarding/active": {
+      "get": {
+        "produces": [
+          "application/json",
+          "application/problem+json"
+        ],
+        "parameters": [
+          {
+            "description": "taxCode",
+            "in": "query",
+            "name": "taxCode",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "productId",
+            "in": "query",
+            "name": "productId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "subunitCode",
+            "in": "query",
+            "name": "subunitCode",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema":{"$ref":"#/definitions/InstitutionOnboardingResourceArray"}
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ],
+        "tags": [
+          "institutions"
+        ],
+        "description": "The service retrieves the active onboarding information for a given tax code and product ID",
+        "operationId": "getActiveOnboardingUsingGET",
+        "summary": "getActiveOnboarding"
       }
     },
     "/v2/institutions/onboarding/aggregation/verification": {
@@ -1677,11 +1893,79 @@
           }
         ],
         "tags": [
+          "billing-portal",
           "institutions"
         ],
         "description": "The service allows to verify if recipientCode is valid or not",
         "operationId": "checkRecipientCodeUsingGET",
         "summary": "checkRecipientCode"
+      }
+    },
+    "/v2/institutions/onboarding/users/pg": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/problem+json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "schema": {
+              "$ref": "#/definitions/CompanyOnboardingUserDto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ],
+        "tags": [
+          "institutions"
+        ],
+        "description": "The service allows the onboarding of Users to a PG Institution",
+        "operationId": "onboardingUsersUsingPOST",
+        "summary": "onboardingUsers"
       }
     },
     "/v2/tokens/{onboardingId}": {
@@ -1808,6 +2092,76 @@
         "description": "Service to approve a specific onboarding request",
         "operationId": "approveOnboardingUsingPOST",
         "summary": "Service to approve a specific onboarding request"
+      }
+    },
+    "/v2/tokens/{onboardingId}/attachment": {
+      "get": {
+        "produces": [
+          "application/octet-stream",
+          "application/problem+json"
+        ],
+        "parameters": [
+          {
+            "description": "Onboarding's unique identifier",
+            "in": "path",
+            "name": "onboardingId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Onboarding's attachment name",
+            "in": "query",
+            "name": "name",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "format": "byte",
+              "type": "string"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ],
+        "tags": [
+          "tokens"
+        ],
+        "description": "Service to download a specific onboarding attachment",
+        "operationId": "getAttachmentUsingGET",
+        "summary": "getAttachment"
       }
     },
     "/v2/tokens/{onboardingId}/complete": {
@@ -2073,6 +2427,76 @@
         "summary": "getContract"
       }
     },
+    "/v2/tokens/{onboardingId}/products/{productId}/aggregates-csv": {
+      "get": {
+        "produces": [
+          "application/octet-stream",
+          "application/problem+json"
+        ],
+        "parameters": [
+          {
+            "description": "Onboarding's unique identifier",
+            "in": "path",
+            "name": "onboardingId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Product's unique identifier",
+            "in": "path",
+            "name": "productId",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "format": "byte",
+              "type": "string"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ],
+        "tags": [
+          "tokens"
+        ],
+        "description": "Service to download a specific onboarding aggregates csv",
+        "operationId": "getAggregatesCsvUsingGET",
+        "summary": "getAggregatesCsv"
+      }
+    },
     "/v2/tokens/{onboardingId}/reject": {
       "post": {
         "consumes": [
@@ -2215,7 +2639,7 @@
       }
     }
   },
-  "definitions" : {"InstitutionResourceArray":{"type": "array", "items": {"$ref": "#/definitions/InstitutionResource"}},"ProductResourceArray":{"type": "array", "items": {"$ref": "#/definitions/ProductResource"}},"ProductResourceArray":{"type": "array", "items": {"$ref": "#/definitions/ProductResource"}},"GeographicTaxonomyResourceArray":{"type": "array", "items": {"$ref": "#/definitions/GeographicTaxonomyResource"}},"GeographicTaxonomyResourceArray":{"type": "array", "items": {"$ref": "#/definitions/GeographicTaxonomyResource"}},"STRINGWrapper":{"type": "string"},"STRINGArray":{"type": "array", "items": {"type": "string"}},"InstitutionResourceArray":{"type": "array", "items": {"$ref": "#/definitions/InstitutionResource"}},
+  "definitions" : {"InstitutionOnboardingResourceArray":{"type": "array", "items": {"$ref": "#/definitions/InstitutionOnboardingResource"}},"InstitutionResourceArray":{"type": "array", "items": {"$ref": "#/definitions/InstitutionResource"}},"ProductResourceArray":{"type": "array", "items": {"$ref": "#/definitions/ProductResource"}},"ProductResourceArray":{"type": "array", "items": {"$ref": "#/definitions/ProductResource"}},"GeographicTaxonomyResourceArray":{"type": "array", "items": {"$ref": "#/definitions/GeographicTaxonomyResource"}},"GeographicTaxonomyResourceArray":{"type": "array", "items": {"$ref": "#/definitions/GeographicTaxonomyResource"}},"STRINGWrapper":{"type": "string"},"STRINGArray":{"type": "array", "items": {"type": "string"}},"InstitutionResourceArray":{"type": "array", "items": {"$ref": "#/definitions/InstitutionResource"}},
     "AdditionalInformations": {
       "properties": {
         "agentOfPublicService": {
@@ -2316,9 +2740,6 @@
         "city": {
           "type": "string"
         },
-        "codeSDI": {
-          "type": "string"
-        },
         "county": {
           "type": "string"
         },
@@ -2352,6 +2773,12 @@
           "type": "string"
         },
         "originId": {
+          "type": "string"
+        },
+        "parentDescription": {
+          "type": "string"
+        },
+        "recipientCode": {
           "type": "string"
         },
         "service": {
@@ -2400,9 +2827,6 @@
         "city": {
           "type": "string"
         },
-        "codeSDI": {
-          "type": "string"
-        },
         "county": {
           "type": "string"
         },
@@ -2419,6 +2843,12 @@
           "type": "string"
         },
         "originId": {
+          "type": "string"
+        },
+        "parentDescription": {
+          "type": "string"
+        },
+        "recipientCode": {
           "type": "string"
         },
         "service": {
@@ -2504,6 +2934,24 @@
         }
       },
       "title": "AssistanceContactsResource",
+      "type": "object"
+    },
+    "Billing": {
+      "properties": {
+        "publicServices": {
+          "type": "boolean"
+        },
+        "recipientCode": {
+          "type": "string"
+        },
+        "taxCodeInvoicing": {
+          "type": "string"
+        },
+        "vatNumber": {
+          "type": "string"
+        }
+      },
+      "title": "Billing",
       "type": "object"
     },
     "BillingDataDto": {
@@ -2617,6 +3065,20 @@
       "title": "BusinessResourceIC",
       "type": "object"
     },
+    "CheckManagerResponse": {
+      "properties": {
+        "result": {
+          "description": "Is the given user manager of the institution",
+          "example": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "result"
+      ],
+      "title": "CheckManagerResponse",
+      "type": "object"
+    },
     "CompanyBillingDataDto": {
       "properties": {
         "businessName": {
@@ -2693,6 +3155,7 @@
           "enum": [
             "AS",
             "CON",
+            "GPU",
             "GSP",
             "PA",
             "PG",
@@ -2729,6 +3192,57 @@
         "users"
       ],
       "title": "CompanyOnboardingDto",
+      "type": "object"
+    },
+    "CompanyOnboardingUserDto": {
+      "properties": {
+        "certified": {
+          "description": "Indicates whether the institution values come from INFOCAMERE (true) or MANUAL (false)",
+          "example": false,
+          "type": "boolean"
+        },
+        "institutionType": {
+          "description": "Institution's type",
+          "enum": [
+            "AS",
+            "CON",
+            "GPU",
+            "GSP",
+            "PA",
+            "PG",
+            "PRV",
+            "PSP",
+            "PT",
+            "REC",
+            "SA",
+            "SCP"
+          ],
+          "type": "string"
+        },
+        "productId": {
+          "description": "Product's unique identifier",
+          "type": "string"
+        },
+        "taxCode": {
+          "description": "Institution's taxCode",
+          "type": "string"
+        },
+        "users": {
+          "description": "List of onboarding users",
+          "items": {
+            "$ref": "#/definitions/CompanyUserDto"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "certified",
+        "institutionType",
+        "productId",
+        "taxCode",
+        "users"
+      ],
+      "title": "CompanyOnboardingUserDto",
       "type": "object"
     },
     "CompanyUserDto": {
@@ -2824,6 +3338,36 @@
       "title": "DpoDataDto",
       "type": "object"
     },
+    "GPUData": {
+      "properties": {
+        "businessRegisterNumber": {
+          "type": "string"
+        },
+        "institutionCourtMeasures": {
+          "type": "boolean"
+        },
+        "legalRegisterName": {
+          "type": "string"
+        },
+        "legalRegisterNumber": {
+          "type": "string"
+        },
+        "manager": {
+          "type": "boolean"
+        },
+        "managerAuthorized": {
+          "type": "boolean"
+        },
+        "managerEligible": {
+          "type": "boolean"
+        },
+        "managerProsecution": {
+          "type": "boolean"
+        }
+      },
+      "title": "GPUData",
+      "type": "object"
+    },
     "GeographicTaxonomyDto": {
       "properties": {
         "code": {
@@ -2891,6 +3435,7 @@
           "enum": [
             "AS",
             "CON",
+            "GPU",
             "GSP",
             "PA",
             "PG",
@@ -2983,6 +3528,7 @@
         "institutionType",
         "mailAddress",
         "name",
+        "vatNumber",
         "zipCode"
       ],
       "title": "InstitutionInfo",
@@ -3020,6 +3566,42 @@
       "title": "InstitutionLocationDataDto",
       "type": "object"
     },
+    "InstitutionOnboarding": {
+      "properties": {
+        "billing": {
+          "$ref": "#/definitions/Billing"
+        },
+        "closedAt": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "contract": {
+          "type": "string"
+        },
+        "createdAt": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "pricingPlan": {
+          "type": "string"
+        },
+        "productId": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "tokenId": {
+          "type": "string"
+        },
+        "updatedAt": {
+          "format": "date-time",
+          "type": "string"
+        }
+      },
+      "title": "InstitutionOnboarding",
+      "type": "object"
+    },
     "InstitutionOnboardingInfoResource": {
       "properties": {
         "geographicTaxonomies": {
@@ -3035,6 +3617,21 @@
         }
       },
       "title": "InstitutionOnboardingInfoResource",
+      "type": "object"
+    },
+    "InstitutionOnboardingResource": {
+      "properties": {
+        "institutionId": {
+          "type": "string"
+        },
+        "onboardings": {
+          "items": {
+            "$ref": "#/definitions/InstitutionOnboarding"
+          },
+          "type": "array"
+        }
+      },
+      "title": "InstitutionOnboardingResource",
       "type": "object"
     },
     "InstitutionResource": {
@@ -3191,6 +3788,10 @@
           },
           "type": "array"
         },
+        "gpuData": {
+          "$ref": "#/definitions/GPUData",
+          "description": "Institution's GPU data"
+        },
         "institutionLocationData": {
           "$ref": "#/definitions/InstitutionLocationDataDto",
           "description": "Institution's location data, city, county, country information"
@@ -3200,6 +3801,7 @@
           "enum": [
             "AS",
             "CON",
+            "GPU",
             "GSP",
             "PA",
             "PG",
@@ -3274,6 +3876,13 @@
           },
           "type": "array"
         },
+        "attachments": {
+          "description": "Onboarding's attachments",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "expiringDate": {
           "description": "Onboarding request expiring date",
           "format": "date-time",
@@ -3319,6 +3928,7 @@
           "enum": [
             "AS",
             "CON",
+            "GPU",
             "GSP",
             "PA",
             "PG",
@@ -3701,6 +4311,34 @@
         }
       },
       "title": "VerifyAggregatesResponse",
+      "type": "object"
+    },
+    "VerifyManagerRequest": {
+      "properties": {
+        "companyTaxCode": {
+          "description": "Institution's taxCode",
+          "type": "string"
+        },
+        "userTaxCode": {
+          "description": "User's fiscal code",
+          "type": "string"
+        }
+      },
+      "title": "VerifyManagerRequest",
+      "type": "object"
+    },
+    "VerifyManagerResponse": {
+      "properties": {
+        "companyName": {
+          "description": "Institution's legal name",
+          "type": "string"
+        },
+        "origin": {
+          "description": "Institution data origin",
+          "type": "string"
+        }
+      },
+      "title": "VerifyManagerResponse",
       "type": "object"
     }
   },

--- a/openApi/onboarding-api-docs.json
+++ b/openApi/onboarding-api-docs.json
@@ -42,7 +42,9 @@
   "paths": {
     "/v1/institutions": {
       "get": {
-        "tags": ["institutions"],
+        "tags": [
+          "institutions"
+        ],
         "summary": "getInstitutions",
         "description": "The service retrieves all the onboarded institutions related to the logged user",
         "operationId": "getInstitutionsUsingGET",
@@ -124,14 +126,18 @@
         },
         "security": [
           {
-            "bearerAuth": ["global"]
+            "bearerAuth": [
+              "global"
+            ]
           }
         ]
       }
     },
     "/v1/institutions/company/onboarding": {
       "post": {
-        "tags": ["institutions"],
+        "tags": [
+          "institutions"
+        ],
         "summary": "onboarding",
         "description": "The service allows the onboarding of Users to a subunit of an Institution",
         "operationId": "onboardingUsingPOST",
@@ -211,14 +217,18 @@
         },
         "security": [
           {
-            "bearerAuth": ["global"]
+            "bearerAuth": [
+              "global"
+            ]
           }
         ]
       }
     },
     "/v1/institutions/from-infocamere/": {
       "get": {
-        "tags": ["institutions"],
+        "tags": [
+          "institutions"
+        ],
         "summary": "getInstitutionsFromInfocamere",
         "description": "Get Legal Representative's PN PG institution List",
         "operationId": "getInstitutionsFromInfocamereUsingGET",
@@ -287,14 +297,18 @@
         },
         "security": [
           {
-            "bearerAuth": ["global"]
+            "bearerAuth": [
+              "global"
+            ]
           }
         ]
       }
     },
     "/v1/institutions/geographicTaxonomies": {
       "get": {
-        "tags": ["institutions"],
+        "tags": [
+          "institutions"
+        ],
         "summary": "getGeographicTaxonomiesByTaxCodeAndSubunitCode",
         "description": "The service retrieve the institution's geographic taxonomy",
         "operationId": "getGeographicTaxonomiesByTaxCodeAndSubunitCodeUsingGET",
@@ -377,14 +391,18 @@
         },
         "security": [
           {
-            "bearerAuth": ["global"]
+            "bearerAuth": [
+              "global"
+            ]
           }
         ]
       }
     },
     "/v1/institutions/onboarding": {
       "post": {
-        "tags": ["institutions"],
+        "tags": [
+          "institutions"
+        ],
         "summary": "onboarding",
         "description": "The service allows the onboarding of Users to a subunit of an Institution",
         "operationId": "onboardingUsingPOST_1",
@@ -464,12 +482,16 @@
         },
         "security": [
           {
-            "bearerAuth": ["global"]
+            "bearerAuth": [
+              "global"
+            ]
           }
         ]
       },
       "head": {
-        "tags": ["institutions"],
+        "tags": [
+          "institutions"
+        ],
         "summary": "verifyOnboarding",
         "description": "Checks if the specified institution has been onboarded on the specified product.",
         "operationId": "verifyOnboardingUsingHEAD",
@@ -542,7 +564,10 @@
             "style": "form",
             "schema": {
               "type": "string",
-              "enum": ["EXTERNAL", "INTERNAL"]
+              "enum": [
+                "EXTERNAL",
+                "INTERNAL"
+              ]
             }
           }
         ],
@@ -603,14 +628,18 @@
         },
         "security": [
           {
-            "bearerAuth": ["global"]
+            "bearerAuth": [
+              "global"
+            ]
           }
         ]
       }
     },
     "/v1/institutions/onboarding/": {
       "get": {
-        "tags": ["institutions"],
+        "tags": [
+          "institutions"
+        ],
         "summary": "getInstitutionOnboardingInfoById",
         "description": "The service retrieves the institutions Manager and institution informations",
         "operationId": "getInstitutionOnboardingInfoUsingGET",
@@ -690,14 +719,18 @@
         },
         "security": [
           {
-            "bearerAuth": ["global"]
+            "bearerAuth": [
+              "global"
+            ]
           }
         ]
       }
     },
     "/v1/institutions/verification/legal-address": {
       "post": {
-        "tags": ["institutions"],
+        "tags": [
+          "institutions"
+        ],
         "summary": "postVerificationLegalAddress",
         "description": "Get legal address by business tax id",
         "operationId": "postVerificationLegalAddressUsingPOST",
@@ -774,14 +807,18 @@
         },
         "security": [
           {
-            "bearerAuth": ["global"]
+            "bearerAuth": [
+              "global"
+            ]
           }
         ]
       }
     },
     "/v1/institutions/verification/match": {
       "post": {
-        "tags": ["institutions"],
+        "tags": [
+          "institutions"
+        ],
         "summary": "postVerificationMatch",
         "description": "MatchLegal Representative and inserted Institution by querying on Agenzia delle Entrate",
         "operationId": "postVerificationMatchUsingPOST",
@@ -858,14 +895,18 @@
         },
         "security": [
           {
-            "bearerAuth": ["global"]
+            "bearerAuth": [
+              "global"
+            ]
           }
         ]
       }
     },
     "/v1/institutions/{externalInstitutionId}/geographicTaxonomy": {
       "get": {
-        "tags": ["institutions"],
+        "tags": [
+          "institutions"
+        ],
         "summary": "getInstitutionGeographicTaxonomy",
         "description": "The service retrieve the institution's geographic taxonomy",
         "operationId": "getInstitutionGeographicTaxonomyUsingGET",
@@ -938,14 +979,18 @@
         },
         "security": [
           {
-            "bearerAuth": ["global"]
+            "bearerAuth": [
+              "global"
+            ]
           }
         ]
       }
     },
     "/v1/institutions/{externalInstitutionId}/products/{productId}": {
       "head": {
-        "tags": ["institutions"],
+        "tags": [
+          "institutions"
+        ],
         "summary": "verifyOnboarding",
         "description": "Checks if the specified institution has been onboarded on the specified product.",
         "operationId": "verifyOnboardingUsingHEAD_1",
@@ -1028,14 +1073,18 @@
         },
         "security": [
           {
-            "bearerAuth": ["global"]
+            "bearerAuth": [
+              "global"
+            ]
           }
         ]
       }
     },
     "/v1/institutions/{externalInstitutionId}/products/{productId}/onboarded-institution-info": {
       "get": {
-        "tags": ["institutions"],
+        "tags": [
+          "institutions"
+        ],
         "summary": "getInstitutionOnboardingInfo",
         "description": "The service retrieves the institutions Manager and institution informations",
         "operationId": "getInstitutionOnboardingInfoUsingGET_1",
@@ -1116,14 +1165,18 @@
         "deprecated": true,
         "security": [
           {
-            "bearerAuth": ["global"]
+            "bearerAuth": [
+              "global"
+            ]
           }
         ]
       }
     },
     "/v2/institutions": {
       "get": {
-        "tags": ["institutions"],
+        "tags": [
+          "institutions"
+        ],
         "summary": "getInstitution",
         "description": "The service allows the onboarding of Users to a subunit of an Institution",
         "operationId": "v2GetInstitutionByFilters",
@@ -1246,14 +1299,18 @@
         },
         "security": [
           {
-            "bearerAuth": ["global"]
+            "bearerAuth": [
+              "global"
+            ]
           }
         ]
       }
     },
     "/v2/institutions/company/onboarding": {
       "post": {
-        "tags": ["institutions"],
+        "tags": [
+          "institutions"
+        ],
         "summary": "onboarding",
         "description": "The service allows the onboarding of Users to a subunit of an Institution",
         "operationId": "onboardingUsingPOST_2",
@@ -1344,14 +1401,106 @@
         },
         "security": [
           {
-            "bearerAuth": ["global"]
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
+      }
+    },
+    "/v2/institutions/company/verify-manager": {
+      "post": {
+        "tags": [
+          "institutions"
+        ],
+        "summary": "verifyManager",
+        "description": "The service allows to verify the legal representative on external registries and retrieve the company name",
+        "operationId": "verifyManagerUsingPOST",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VerifyManagerRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VerifyManagerResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
           }
         ]
       }
     },
     "/v2/institutions/onboarding": {
       "post": {
-        "tags": ["institutions"],
+        "tags": [
+          "institutions"
+        ],
         "summary": "onboarding",
         "description": "The service allows the onboarding of Users to a subunit of an Institution",
         "operationId": "onboardingUsingPOST_3",
@@ -1431,14 +1580,122 @@
         },
         "security": [
           {
-            "bearerAuth": ["global"]
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
+      }
+    },
+    "/v2/institutions/onboarding/active": {
+      "get": {
+        "tags": [
+          "institutions"
+        ],
+        "summary": "getActiveOnboarding",
+        "description": "The service retrieves the active onboarding information for a given tax code and product ID",
+        "operationId": "getActiveOnboardingUsingGET",
+        "parameters": [
+          {
+            "name": "taxCode",
+            "in": "query",
+            "description": "taxCode",
+            "required": true,
+            "style": "form",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "productId",
+            "in": "query",
+            "description": "productId",
+            "required": true,
+            "style": "form",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "subunitCode",
+            "in": "query",
+            "description": "subunitCode",
+            "required": false,
+            "style": "form",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/InstitutionOnboardingResource"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
           }
         ]
       }
     },
     "/v2/institutions/onboarding/aggregation/verification": {
       "post": {
-        "tags": ["institutions"],
+        "tags": [
+          "institutions"
+        ],
         "summary": "verifyAggregatesCsv",
         "description": "The service allows to verify if the given csv contains valid aggregate institutions",
         "operationId": "verifyAggregatesCsvUsingPOST",
@@ -1544,14 +1801,19 @@
         },
         "security": [
           {
-            "bearerAuth": ["global"]
+            "bearerAuth": [
+              "global"
+            ]
           }
         ]
       }
     },
     "/v2/institutions/onboarding/recipientCode/verification": {
       "get": {
-        "tags": ["institutions"],
+        "tags": [
+          "billing-portal",
+          "institutions"
+        ],
         "summary": "checkRecipientCode",
         "description": "The service allows to verify if recipientCode is valid or not",
         "operationId": "checkRecipientCodeUsingGET",
@@ -1584,7 +1846,11 @@
               "application/json": {
                 "schema": {
                   "type": "string",
-                  "enum": ["ACCEPTED", "DENIED_NO_ASSOCIATION", "DENIED_NO_BILLING"]
+                  "enum": [
+                    "ACCEPTED",
+                    "DENIED_NO_ASSOCIATION",
+                    "DENIED_NO_BILLING"
+                  ]
                 }
               }
             }
@@ -1632,14 +1898,99 @@
         },
         "security": [
           {
-            "bearerAuth": ["global"]
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
+      }
+    },
+    "/v2/institutions/onboarding/users/pg": {
+      "post": {
+        "tags": [
+          "institutions"
+        ],
+        "summary": "onboardingUsers",
+        "description": "The service allows the onboarding of Users to a PG Institution",
+        "operationId": "onboardingUsersUsingPOST",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CompanyOnboardingUserDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
           }
         ]
       }
     },
     "/v1/product/{id}": {
       "get": {
-        "tags": ["product"],
+        "tags": [
+          "product"
+        ],
         "summary": "getProduct",
         "description": "The service retrieves the product given its internal id",
         "operationId": "getProductUsingGET",
@@ -1662,7 +2013,20 @@
             "style": "form",
             "schema": {
               "type": "string",
-              "enum": ["AS", "CON", "GSP", "PA", "PG", "PRV", "PSP", "PT", "REC", "SA", "SCP"]
+              "enum": [
+                "AS",
+                "CON",
+                "GPU",
+                "GSP",
+                "PA",
+                "PG",
+                "PRV",
+                "PSP",
+                "PT",
+                "REC",
+                "SA",
+                "SCP"
+              ]
             }
           }
         ],
@@ -1720,14 +2084,18 @@
         },
         "security": [
           {
-            "bearerAuth": ["global"]
+            "bearerAuth": [
+              "global"
+            ]
           }
         ]
       }
     },
     "/v1/products": {
       "get": {
-        "tags": ["product"],
+        "tags": [
+          "product"
+        ],
         "summary": "getProducts",
         "description": "The service retrieves all products",
         "operationId": "getProducts",
@@ -1788,14 +2156,18 @@
         },
         "security": [
           {
-            "bearerAuth": ["global"]
+            "bearerAuth": [
+              "global"
+            ]
           }
         ]
       }
     },
     "/v1/products/admin": {
       "get": {
-        "tags": ["product"],
+        "tags": [
+          "product"
+        ],
         "summary": "getProductsAdmin",
         "description": "The service retrieves all products for the addition administration functionality",
         "operationId": "getProductsAdmin",
@@ -1856,14 +2228,18 @@
         },
         "security": [
           {
-            "bearerAuth": ["global"]
+            "bearerAuth": [
+              "global"
+            ]
           }
         ]
       }
     },
     "/v2/tokens/{onboardingId}": {
       "get": {
-        "tags": ["tokens"],
+        "tags": [
+          "tokens"
+        ],
         "summary": "retrieveOnboardingRequest",
         "description": "Service to retrieve a specific onboarding request",
         "operationId": "retrieveOnboardingRequestUsingGET",
@@ -1933,14 +2309,18 @@
         },
         "security": [
           {
-            "bearerAuth": ["global"]
+            "bearerAuth": [
+              "global"
+            ]
           }
         ]
       }
     },
     "/v2/tokens/{onboardingId}/approve": {
       "post": {
-        "tags": ["tokens"],
+        "tags": [
+          "tokens"
+        ],
         "summary": "Service to approve a specific onboarding request",
         "description": "Service to approve a specific onboarding request",
         "operationId": "approveOnboardingUsingPOST",
@@ -2013,14 +2393,110 @@
         },
         "security": [
           {
-            "bearerAuth": ["global"]
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
+      }
+    },
+    "/v2/tokens/{onboardingId}/attachment": {
+      "get": {
+        "tags": [
+          "tokens"
+        ],
+        "summary": "getAttachment",
+        "description": "Service to download a specific onboarding attachment",
+        "operationId": "getAttachmentUsingGET",
+        "parameters": [
+          {
+            "name": "onboardingId",
+            "in": "path",
+            "description": "Onboarding's unique identifier",
+            "required": true,
+            "style": "simple",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "description": "Onboarding's attachment name",
+            "required": true,
+            "style": "form",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "byte"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
           }
         ]
       }
     },
     "/v2/tokens/{onboardingId}/complete": {
       "post": {
-        "tags": ["tokens"],
+        "tags": [
+          "tokens"
+        ],
         "summary": "Complete an onboarding request",
         "description": "Complete an onboarding request",
         "operationId": "completeUsingPOST",
@@ -2040,7 +2516,9 @@
           "content": {
             "multipart/form-data": {
               "schema": {
-                "required": ["contract"],
+                "required": [
+                  "contract"
+                ],
                 "type": "object",
                 "properties": {
                   "contract": {
@@ -2110,12 +2588,16 @@
         },
         "security": [
           {
-            "bearerAuth": ["global"]
+            "bearerAuth": [
+              "global"
+            ]
           }
         ]
       },
       "delete": {
-        "tags": ["tokens"],
+        "tags": [
+          "tokens"
+        ],
         "summary": "Complete an onboarding request",
         "description": "Complete an onboarding request",
         "operationId": "deleteUsingDELETE",
@@ -2168,14 +2650,18 @@
         },
         "security": [
           {
-            "bearerAuth": ["global"]
+            "bearerAuth": [
+              "global"
+            ]
           }
         ]
       }
     },
     "/v2/tokens/{onboardingId}/completeOnboardingUsers": {
       "post": {
-        "tags": ["tokens"],
+        "tags": [
+          "tokens"
+        ],
         "summary": "Complete an onboarding users request",
         "description": "Complete an onboarding users request",
         "operationId": "completeOnboardingUsersUsingPOST",
@@ -2195,7 +2681,9 @@
           "content": {
             "multipart/form-data": {
               "schema": {
-                "required": ["contract"],
+                "required": [
+                  "contract"
+                ],
                 "type": "object",
                 "properties": {
                   "contract": {
@@ -2265,14 +2753,18 @@
         },
         "security": [
           {
-            "bearerAuth": ["global"]
+            "bearerAuth": [
+              "global"
+            ]
           }
         ]
       }
     },
     "/v2/tokens/{onboardingId}/contract": {
       "get": {
-        "tags": ["tokens"],
+        "tags": [
+          "tokens"
+        ],
         "summary": "getContract",
         "description": "Service to download a specific onboarding contract",
         "operationId": "getContractUsingGET",
@@ -2343,14 +2835,110 @@
         },
         "security": [
           {
-            "bearerAuth": ["global"]
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
+      }
+    },
+    "/v2/tokens/{onboardingId}/products/{productId}/aggregates-csv": {
+      "get": {
+        "tags": [
+          "tokens"
+        ],
+        "summary": "getAggregatesCsv",
+        "description": "Service to download a specific onboarding aggregates csv",
+        "operationId": "getAggregatesCsvUsingGET",
+        "parameters": [
+          {
+            "name": "onboardingId",
+            "in": "path",
+            "description": "Onboarding's unique identifier",
+            "required": true,
+            "style": "simple",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "productId",
+            "in": "path",
+            "description": "Product's unique identifier",
+            "required": true,
+            "style": "simple",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "byte"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
           }
         ]
       }
     },
     "/v2/tokens/{onboardingId}/reject": {
       "post": {
-        "tags": ["tokens"],
+        "tags": [
+          "tokens"
+        ],
         "summary": "Service to reject a specific onboarding request",
         "operationId": "rejectOnboardingUsingPOST",
         "parameters": [
@@ -2431,14 +3019,18 @@
         },
         "security": [
           {
-            "bearerAuth": ["global"]
+            "bearerAuth": [
+              "global"
+            ]
           }
         ]
       }
     },
     "/v2/tokens/{onboardingId}/verify": {
       "post": {
-        "tags": ["tokens"],
+        "tags": [
+          "tokens"
+        ],
         "summary": "Verify if the token is already consumed",
         "description": "Verify if the token is already consumed",
         "operationId": "verifyOnboardingUsingPOST",
@@ -2518,14 +3110,18 @@
         },
         "security": [
           {
-            "bearerAuth": ["global"]
+            "bearerAuth": [
+              "global"
+            ]
           }
         ]
       }
     },
     "/v1/users/check-manager": {
       "post": {
-        "tags": ["user"],
+        "tags": [
+          "user"
+        ],
         "summary": "checkManager",
         "description": "Returns true if current manager and previous one are the same",
         "operationId": "checkManager",
@@ -2544,10 +3140,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "boolean"
-                  }
+                  "$ref": "#/components/schemas/CheckManagerResponse"
                 }
               }
             }
@@ -2615,14 +3208,18 @@
         },
         "security": [
           {
-            "bearerAuth": ["global"]
+            "bearerAuth": [
+              "global"
+            ]
           }
         ]
       }
     },
     "/v1/users/onboarding": {
       "post": {
-        "tags": ["user"],
+        "tags": [
+          "user"
+        ],
         "summary": "onboarding",
         "description": "The service allows the onboarding of Users",
         "operationId": "onboardingUsingPOST_4",
@@ -2702,14 +3299,109 @@
         },
         "security": [
           {
-            "bearerAuth": ["global"]
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/users/onboarding/aggregator": {
+      "post": {
+        "tags": [
+          "user"
+        ],
+        "summary": "onboardingAggregator",
+        "description": "The service allows the onboarding of Users for aggregators",
+        "operationId": "onboardingAggregatorUsingPOST",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OnboardingUserDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
           }
         ]
       }
     },
     "/v1/users/validate": {
       "post": {
-        "tags": ["user"],
+        "tags": [
+          "user"
+        ],
         "summary": "validate",
         "description": "Check if requested user data are valid",
         "operationId": "validateUsingPOST",
@@ -2779,7 +3471,9 @@
         },
         "security": [
           {
-            "bearerAuth": ["global"]
+            "bearerAuth": [
+              "global"
+            ]
           }
         ]
       }
@@ -2881,16 +3575,16 @@
       },
       "AggregateInstitution": {
         "title": "AggregateInstitution",
-        "required": ["description", "taxCode"],
+        "required": [
+          "description",
+          "taxCode"
+        ],
         "type": "object",
         "properties": {
           "address": {
             "type": "string"
           },
           "city": {
-            "type": "string"
-          },
-          "codeSDI": {
             "type": "string"
           },
           "county": {
@@ -2926,6 +3620,12 @@
             ]
           },
           "originId": {
+            "type": "string"
+          },
+          "parentDescription": {
+            "type": "string"
+          },
+          "recipientCode": {
             "type": "string"
           },
           "service": {
@@ -2970,9 +3670,6 @@
           "city": {
             "type": "string"
           },
-          "codeSDI": {
-            "type": "string"
-          },
           "county": {
             "type": "string"
           },
@@ -2989,6 +3686,12 @@
             "type": "string"
           },
           "originId": {
+            "type": "string"
+          },
+          "parentDescription": {
+            "type": "string"
+          },
+          "recipientCode": {
             "type": "string"
           },
           "service": {
@@ -3074,9 +3777,31 @@
           }
         }
       },
+      "Billing": {
+        "title": "Billing",
+        "type": "object",
+        "properties": {
+          "publicServices": {
+            "type": "boolean"
+          },
+          "recipientCode": {
+            "type": "string"
+          },
+          "taxCodeInvoicing": {
+            "type": "string"
+          },
+          "vatNumber": {
+            "type": "string"
+          }
+        }
+      },
       "BillingDataDto": {
         "title": "BillingDataDto",
-        "required": ["businessName", "digitalAddress", "registeredOffice"],
+        "required": [
+          "businessName",
+          "digitalAddress",
+          "registeredOffice"
+        ],
         "type": "object",
         "properties": {
           "businessName": {
@@ -3181,9 +3906,28 @@
           }
         }
       },
+      "CheckManagerResponse": {
+        "title": "CheckManagerResponse",
+        "required": [
+          "result"
+        ],
+        "type": "object",
+        "properties": {
+          "result": {
+            "type": "boolean",
+            "description": "Is the given user manager of the institution",
+            "example": false
+          }
+        }
+      },
       "CompanyBillingDataDto": {
         "title": "CompanyBillingDataDto",
-        "required": ["businessName", "certified", "digitalAddress", "taxCode"],
+        "required": [
+          "businessName",
+          "certified",
+          "digitalAddress",
+          "taxCode"
+        ],
         "type": "object",
         "properties": {
           "businessName": {
@@ -3243,7 +3987,13 @@
       },
       "CompanyOnboardingDto": {
         "title": "CompanyOnboardingDto",
-        "required": ["billingData", "institutionType", "productId", "taxCode", "users"],
+        "required": [
+          "billingData",
+          "institutionType",
+          "productId",
+          "taxCode",
+          "users"
+        ],
         "type": "object",
         "properties": {
           "billingData": {
@@ -3253,7 +4003,71 @@
           "institutionType": {
             "type": "string",
             "description": "Institution's type",
-            "enum": ["AS", "CON", "GSP", "PA", "PG", "PRV", "PSP", "PT", "REC", "SA", "SCP"]
+            "enum": [
+              "AS",
+              "CON",
+              "GPU",
+              "GSP",
+              "PA",
+              "PG",
+              "PRV",
+              "PSP",
+              "PT",
+              "REC",
+              "SA",
+              "SCP"
+            ]
+          },
+          "productId": {
+            "type": "string",
+            "description": "Product's unique identifier"
+          },
+          "taxCode": {
+            "type": "string",
+            "description": "Institution's taxCode"
+          },
+          "users": {
+            "type": "array",
+            "description": "List of onboarding users",
+            "items": {
+              "$ref": "#/components/schemas/CompanyUserDto"
+            }
+          }
+        }
+      },
+      "CompanyOnboardingUserDto": {
+        "title": "CompanyOnboardingUserDto",
+        "required": [
+          "certified",
+          "institutionType",
+          "productId",
+          "taxCode",
+          "users"
+        ],
+        "type": "object",
+        "properties": {
+          "certified": {
+            "type": "boolean",
+            "description": "Indicates whether the institution values come from INFOCAMERE (true) or MANUAL (false)",
+            "example": false
+          },
+          "institutionType": {
+            "type": "string",
+            "description": "Institution's type",
+            "enum": [
+              "AS",
+              "CON",
+              "GPU",
+              "GSP",
+              "PA",
+              "PG",
+              "PRV",
+              "PSP",
+              "PT",
+              "REC",
+              "SA",
+              "SCP"
+            ]
           },
           "productId": {
             "type": "string",
@@ -3274,7 +4088,12 @@
       },
       "CompanyUserDto": {
         "title": "CompanyUserDto",
-        "required": ["name", "role", "surname", "taxCode"],
+        "required": [
+          "name",
+          "role",
+          "surname",
+          "taxCode"
+        ],
         "type": "object",
         "properties": {
           "email": {
@@ -3288,7 +4107,13 @@
           "role": {
             "type": "string",
             "description": "User's role",
-            "enum": ["ADMIN_EA", "DELEGATE", "MANAGER", "OPERATOR", "SUB_DELEGATE"]
+            "enum": [
+              "ADMIN_EA",
+              "DELEGATE",
+              "MANAGER",
+              "OPERATOR",
+              "SUB_DELEGATE"
+            ]
           },
           "surname": {
             "type": "string",
@@ -3302,7 +4127,11 @@
       },
       "DpoData": {
         "title": "DpoData",
-        "required": ["address", "email", "pec"],
+        "required": [
+          "address",
+          "email",
+          "pec"
+        ],
         "type": "object",
         "properties": {
           "address": {
@@ -3325,7 +4154,11 @@
       },
       "DpoDataDto": {
         "title": "DpoDataDto",
-        "required": ["address", "email", "pec"],
+        "required": [
+          "address",
+          "email",
+          "pec"
+        ],
         "type": "object",
         "properties": {
           "address": {
@@ -3346,9 +4179,42 @@
           }
         }
       },
+      "GPUData": {
+        "title": "GPUData",
+        "type": "object",
+        "properties": {
+          "businessRegisterNumber": {
+            "type": "string"
+          },
+          "institutionCourtMeasures": {
+            "type": "boolean"
+          },
+          "legalRegisterName": {
+            "type": "string"
+          },
+          "legalRegisterNumber": {
+            "type": "string"
+          },
+          "manager": {
+            "type": "boolean"
+          },
+          "managerAuthorized": {
+            "type": "boolean"
+          },
+          "managerEligible": {
+            "type": "boolean"
+          },
+          "managerProsecution": {
+            "type": "boolean"
+          }
+        }
+      },
       "GeographicTaxonomyDto": {
         "title": "GeographicTaxonomyDto",
-        "required": ["code", "desc"],
+        "required": [
+          "code",
+          "desc"
+        ],
         "type": "object",
         "properties": {
           "code": {
@@ -3410,7 +4276,20 @@
           "institutionType": {
             "type": "string",
             "description": "Institution's type",
-            "enum": ["AS", "CON", "GSP", "PA", "PG", "PRV", "PSP", "PT", "REC", "SA", "SCP"]
+            "enum": [
+              "AS",
+              "CON",
+              "GPU",
+              "GSP",
+              "PA",
+              "PG",
+              "PRV",
+              "PSP",
+              "PT",
+              "REC",
+              "SA",
+              "SCP"
+            ]
           },
           "origin": {
             "type": "string"
@@ -3425,6 +4304,7 @@
           "institutionType",
           "mailAddress",
           "name",
+          "vatNumber",
           "zipCode"
         ],
         "type": "object",
@@ -3527,6 +4407,42 @@
           }
         }
       },
+      "InstitutionOnboarding": {
+        "title": "InstitutionOnboarding",
+        "type": "object",
+        "properties": {
+          "billing": {
+            "$ref": "#/components/schemas/Billing"
+          },
+          "closedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "contract": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "pricingPlan": {
+            "type": "string"
+          },
+          "productId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "tokenId": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
       "InstitutionOnboardingInfoResource": {
         "title": "InstitutionOnboardingInfoResource",
         "type": "object",
@@ -3541,6 +4457,21 @@
           "institution": {
             "description": "Institution's billing and type information",
             "$ref": "#/components/schemas/InstitutionData"
+          }
+        }
+      },
+      "InstitutionOnboardingResource": {
+        "title": "InstitutionOnboardingResource",
+        "type": "object",
+        "properties": {
+          "institutionId": {
+            "type": "string"
+          },
+          "onboardings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InstitutionOnboarding"
+            }
           }
         }
       },
@@ -3604,7 +4535,11 @@
           "userRole": {
             "type": "string",
             "description": "Logged user's role",
-            "enum": ["ADMIN", "ADMIN_EA", "LIMITED"]
+            "enum": [
+              "ADMIN",
+              "ADMIN_EA",
+              "LIMITED"
+            ]
           },
           "zipCode": {
             "type": "string",
@@ -3635,7 +4570,10 @@
       },
       "InvalidParam": {
         "title": "InvalidParam",
-        "required": ["name", "reason"],
+        "required": [
+          "name",
+          "reason"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -3661,7 +4599,11 @@
       },
       "OnboardingProductDto": {
         "title": "OnboardingProductDto",
-        "required": ["institutionType", "productId", "users"],
+        "required": [
+          "institutionType",
+          "productId",
+          "users"
+        ],
         "type": "object",
         "properties": {
           "additionalInformations": {
@@ -3694,6 +4636,10 @@
               "$ref": "#/components/schemas/GeographicTaxonomyDto"
             }
           },
+          "gpuData": {
+            "description": "Institution's GPU data",
+            "$ref": "#/components/schemas/GPUData"
+          },
           "institutionLocationData": {
             "description": "Institution's location data, city, county, country information",
             "$ref": "#/components/schemas/InstitutionLocationDataDto"
@@ -3701,7 +4647,20 @@
           "institutionType": {
             "type": "string",
             "description": "Institution's type",
-            "enum": ["AS", "CON", "GSP", "PA", "PG", "PRV", "PSP", "PT", "REC", "SA", "SCP"]
+            "enum": [
+              "AS",
+              "CON",
+              "GPU",
+              "GSP",
+              "PA",
+              "PG",
+              "PRV",
+              "PSP",
+              "PT",
+              "REC",
+              "SA",
+              "SCP"
+            ]
           },
           "isAggregator": {
             "type": "boolean",
@@ -3751,7 +4710,10 @@
       },
       "OnboardingRequestResource": {
         "title": "OnboardingRequestResource",
-        "required": ["institutionInfo", "status"],
+        "required": [
+          "institutionInfo",
+          "status"
+        ],
         "type": "object",
         "properties": {
           "admins": {
@@ -3759,6 +4721,13 @@
             "description": "Administrators specific data",
             "items": {
               "$ref": "#/components/schemas/UserInfo"
+            }
+          },
+          "attachments": {
+            "type": "array",
+            "description": "Onboarding's attachments",
+            "items": {
+              "type": "string"
             }
           },
           "expiringDate": {
@@ -3795,13 +4764,29 @@
       },
       "OnboardingUserDto": {
         "title": "OnboardingUserDto",
-        "required": ["productId", "users"],
+        "required": [
+          "productId",
+          "users"
+        ],
         "type": "object",
         "properties": {
           "institutionType": {
             "type": "string",
             "description": "Institution's type",
-            "enum": ["AS", "CON", "GSP", "PA", "PG", "PRV", "PSP", "PT", "REC", "SA", "SCP"]
+            "enum": [
+              "AS",
+              "CON",
+              "GPU",
+              "GSP",
+              "PA",
+              "PG",
+              "PRV",
+              "PSP",
+              "PT",
+              "REC",
+              "SA",
+              "SCP"
+            ]
           },
           "origin": {
             "type": "string",
@@ -3834,7 +4819,9 @@
       },
       "OnboardingVerify": {
         "title": "OnboardingVerify",
-        "required": ["status"],
+        "required": [
+          "status"
+        ],
         "type": "object",
         "properties": {
           "expiringDate": {
@@ -3854,7 +4841,10 @@
       },
       "Problem": {
         "title": "Problem",
-        "required": ["status", "title"],
+        "required": [
+          "status",
+          "title"
+        ],
         "type": "object",
         "properties": {
           "detail": {
@@ -3912,7 +4902,12 @@
           "status": {
             "type": "string",
             "description": "Product's status",
-            "enum": ["ACTIVE", "INACTIVE", "PHASE_OUT", "TESTING"]
+            "enum": [
+              "ACTIVE",
+              "INACTIVE",
+              "PHASE_OUT",
+              "TESTING"
+            ]
           },
           "title": {
             "type": "string",
@@ -4021,7 +5016,9 @@
       },
       "UserDataValidationDto": {
         "title": "UserDataValidationDto",
-        "required": ["taxCode"],
+        "required": [
+          "taxCode"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -4040,7 +5037,12 @@
       },
       "UserDto": {
         "title": "UserDto",
-        "required": ["name", "role", "surname", "taxCode"],
+        "required": [
+          "name",
+          "role",
+          "surname",
+          "taxCode"
+        ],
         "type": "object",
         "properties": {
           "email": {
@@ -4054,7 +5056,13 @@
           "role": {
             "type": "string",
             "description": "User's role",
-            "enum": ["ADMIN_EA", "DELEGATE", "MANAGER", "OPERATOR", "SUB_DELEGATE"]
+            "enum": [
+              "ADMIN_EA",
+              "DELEGATE",
+              "MANAGER",
+              "OPERATOR",
+              "SUB_DELEGATE"
+            ]
           },
           "surname": {
             "type": "string",
@@ -4068,7 +5076,13 @@
       },
       "UserInfo": {
         "title": "UserInfo",
-        "required": ["email", "fiscalCode", "id", "name", "surname"],
+        "required": [
+          "email",
+          "fiscalCode",
+          "id",
+          "name",
+          "surname"
+        ],
         "type": "object",
         "properties": {
           "email": {
@@ -4096,7 +5110,9 @@
       },
       "VerificationLegalAddressRequest": {
         "title": "VerificationLegalAddressRequest",
-        "required": ["taxCode"],
+        "required": [
+          "taxCode"
+        ],
         "type": "object",
         "properties": {
           "taxCode": {
@@ -4106,7 +5122,10 @@
       },
       "VerificationMatchRequest": {
         "title": "VerificationMatchRequest",
-        "required": ["taxCode", "userDto"],
+        "required": [
+          "taxCode",
+          "userDto"
+        ],
         "type": "object",
         "properties": {
           "taxCode": {
@@ -4132,6 +5151,34 @@
             "items": {
               "$ref": "#/components/schemas/RowErrorResponse"
             }
+          }
+        }
+      },
+      "VerifyManagerRequest": {
+        "title": "VerifyManagerRequest",
+        "type": "object",
+        "properties": {
+          "companyTaxCode": {
+            "type": "string",
+            "description": "Institution's taxCode"
+          },
+          "userTaxCode": {
+            "type": "string",
+            "description": "User's fiscal code"
+          }
+        }
+      },
+      "VerifyManagerResponse": {
+        "title": "VerifyManagerResponse",
+        "type": "object",
+        "properties": {
+          "companyName": {
+            "type": "string",
+            "description": "Institution's legal name"
+          },
+          "origin": {
+            "type": "string",
+            "description": "Institution data origin"
           }
         }
       }

--- a/src/api/OnboardingApiClient.ts
+++ b/src/api/OnboardingApiClient.ts
@@ -1,4 +1,4 @@
-// import { storageTokenOps } from '@pagopa/selfcare-common-frontend/lib/utils/storage';
+import { storageTokenOps } from '@pagopa/selfcare-common-frontend/lib/utils/storage';
 import {
   buildFetchApi,
   extractResponse,
@@ -10,7 +10,7 @@ import { createClient, WithDefaultsT } from './generated/onboarding/client';
 
 const withBearerAndInstitutionId: WithDefaultsT<'bearerAuth'> =
   (wrappedOperation) => (params: any) => {
-    const token = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Imp3dF9hMjo3YTo0NjozYjoyYTo2MDo1Njo0MDo4ODphMDo1ZDphNDpmODowMToxZTozZSJ9.eyJmYW1pbHlfbmFtZSI6InNpc3RpIiwiZmlzY2FsX251bWJlciI6IlNTVE1UVDgwQTAxRjIwNUMiLCJuYW1lIjoibWF0dGlhIiwic3BpZF9sZXZlbCI6Imh0dHBzOi8vd3d3LnNwaWQuZ292Lml0L1NwaWRMMiIsImZyb21fYWEiOmZhbHNlLCJ1aWQiOiJkZWE1ZDJjNC05YzNiLTQ3YzEtYmQ5YS0zZTM4YTIwMzcwMDkiLCJsZXZlbCI6IkwyIiwiaWF0IjoxNzMzNzM2NzU1LCJleHAiOjE3MzM3NjkxNTUsImF1ZCI6ImFwaS5kZXYuc2VsZmNhcmUucGFnb3BhLml0IiwiaXNzIjoiU1BJRCIsImp0aSI6Il8wY2M1ODE5YjY2YWNlMjA3MzdiNCJ9.blijFdaw5nrB93U1rYAm6hHNp9cqQe2ABSHwzMeIM3gBuLbpkU_B4s-QJUyIAq29EeHA26V6_uN6SFOmKYSLk2KW9ozNHEO4B_hiDwxjIRz5hVFGaVapEbjppjzOy1BAexyGDhF2WLtxbj5i5k8Dj9djIFgNkZ1cTnMy-IzLVnY5efkBCoCyUziCCRxkTwSrKpoTQdqrG2fJbciPL2O8CL52TxQWN4a-GVFNwjnpQPBj_qvsdyKP_ypP02OeaP7W-0JvJ2UCCdxVUYmhpzOtjmw1PLgs0Ig9yh1_1eKzCBf-rPlsuXIsZT5Zk6fz6NW2r2aL_RSRslF1FOUE9SxMKA';
+    const token = storageTokenOps.read();
     return wrappedOperation({
       ...params,
       bearerAuth: `Bearer ${token}`,

--- a/src/api/OnboardingApiClient.ts
+++ b/src/api/OnboardingApiClient.ts
@@ -1,4 +1,4 @@
-import { storageTokenOps } from '@pagopa/selfcare-common-frontend/lib/utils/storage';
+// import { storageTokenOps } from '@pagopa/selfcare-common-frontend/lib/utils/storage';
 import {
   buildFetchApi,
   extractResponse,
@@ -10,7 +10,7 @@ import { createClient, WithDefaultsT } from './generated/onboarding/client';
 
 const withBearerAndInstitutionId: WithDefaultsT<'bearerAuth'> =
   (wrappedOperation) => (params: any) => {
-    const token = storageTokenOps.read();
+    const token = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Imp3dF9hMjo3YTo0NjozYjoyYTo2MDo1Njo0MDo4ODphMDo1ZDphNDpmODowMToxZTozZSJ9.eyJmYW1pbHlfbmFtZSI6InNpc3RpIiwiZmlzY2FsX251bWJlciI6IlNTVE1UVDgwQTAxRjIwNUMiLCJuYW1lIjoibWF0dGlhIiwic3BpZF9sZXZlbCI6Imh0dHBzOi8vd3d3LnNwaWQuZ292Lml0L1NwaWRMMiIsImZyb21fYWEiOmZhbHNlLCJ1aWQiOiJkZWE1ZDJjNC05YzNiLTQ3YzEtYmQ5YS0zZTM4YTIwMzcwMDkiLCJsZXZlbCI6IkwyIiwiaWF0IjoxNzMzNzM2NzU1LCJleHAiOjE3MzM3NjkxNTUsImF1ZCI6ImFwaS5kZXYuc2VsZmNhcmUucGFnb3BhLml0IiwiaXNzIjoiU1BJRCIsImp0aSI6Il8wY2M1ODE5YjY2YWNlMjA3MzdiNCJ9.blijFdaw5nrB93U1rYAm6hHNp9cqQe2ABSHwzMeIM3gBuLbpkU_B4s-QJUyIAq29EeHA26V6_uN6SFOmKYSLk2KW9ozNHEO4B_hiDwxjIRz5hVFGaVapEbjppjzOy1BAexyGDhF2WLtxbj5i5k8Dj9djIFgNkZ1cTnMy-IzLVnY5efkBCoCyUziCCRxkTwSrKpoTQdqrG2fJbciPL2O8CL52TxQWN4a-GVFNwjnpQPBj_qvsdyKP_ypP02OeaP7W-0JvJ2UCCdxVUYmhpzOtjmw1PLgs0Ig9yh1_1eKzCBf-rPlsuXIsZT5Zk6fz6NW2r2aL_RSRslF1FOUE9SxMKA';
     return wrappedOperation({
       ...params,
       bearerAuth: `Bearer ${token}`,
@@ -58,6 +58,14 @@ export const OnboardingApi = {
   approveOnboardingRequest: async (onboardingId: string): Promise<OnboardingRequestResource> => {
     const result = await apiClient.approveOnboardingUsingPOST({
       onboardingId,
+    });
+    return extractResponse(result, 200, onRedirectToLogin);
+  },
+
+  downloadOnboardingAttachments: async (onboardingId: string, name: string): Promise<any> => {
+    const result = await apiClient.getAttachmentUsingGET({
+      onboardingId,
+      name,
     });
     return extractResponse(result, 200, onRedirectToLogin);
   },

--- a/src/locale/it.ts
+++ b/src/locale/it.ts
@@ -112,6 +112,8 @@ export default {
         },
       },
       approveButton: 'Approva',
+      downloadButton: 'Scarica',
+      downloadDataButton: 'Scarica i dati'
     },
   },
   jwtNotValid: {

--- a/src/model/OnboardingRequestResource.ts
+++ b/src/model/OnboardingRequestResource.ts
@@ -46,6 +46,7 @@ type InstitutionInfo = {
   recipientCode?: string;
   vatNumber?: string;
   additionalInformations?: AdditionalInformations;
+  attachments?: Array<string>;
 };
 
 type PspData = {

--- a/src/pages/dashboardRequest/components/DashboardRequestActions.tsx
+++ b/src/pages/dashboardRequest/components/DashboardRequestActions.tsx
@@ -3,9 +3,11 @@ import { theme } from '@pagopa/mui-italia';
 import { useTranslation, Trans } from 'react-i18next';
 import { Dispatch, SetStateAction, useState } from 'react';
 import { SessionModal, useErrorDispatcher, useLoading } from '@pagopa/selfcare-common-frontend/lib';
+import FileDownloadIcon from '@mui/icons-material/FileDownload';
 import { LOADING_RETRIEVE_ONBOARDING_REQUEST } from '../../../utils/constants';
 import {
   approveOnboardingPspRequest,
+  downloadOnboardingAttachments,
   rejectOnboardingRequest,
 } from '../../../services/onboardingRequestService';
 
@@ -13,6 +15,7 @@ type Props = {
   setShowRejectPage: Dispatch<SetStateAction<boolean | undefined>>;
   setShowConfirmPage: Dispatch<SetStateAction<boolean | undefined>>;
   isToBeValidatedRequest: boolean;
+  isGPU: boolean;
   retrieveTokenIdFromUrl?: string;
   partyName?: string;
   productTitle?: string;
@@ -22,6 +25,7 @@ export default function DashboardRequestActions({
   setShowRejectPage,
   setShowConfirmPage,
   isToBeValidatedRequest,
+  isGPU,
   retrieveTokenIdFromUrl,
   partyName,
   productTitle,
@@ -72,6 +76,28 @@ export default function DashboardRequestActions({
     }
   };
 
+  const downloadAttachment = () => {
+    setLoadingRetrieveOnboardingRequest(true);
+    if (retrieveTokenIdFromUrl) {
+      downloadOnboardingAttachments(retrieveTokenIdFromUrl, '')
+        .then(() => {
+          setShowConfirmPage(false);
+          console.log('download dummy');
+        })
+        // eslint-disable-next-line sonarjs/no-identical-functions
+        .catch((reason: any) => {
+          addError({
+            id: `Onboarding request with tokenId: ${retrieveTokenIdFromUrl} not approved`,
+            blocking: false,
+            techDescription: reason,
+            toNotify: false,
+            error: new Error('INVALID_TOKEN_ID'),
+          });
+        })
+        .finally(() => setLoadingRetrieveOnboardingRequest(false));
+    }
+  };
+
   return (
     <>
       {isToBeValidatedRequest && (
@@ -87,11 +113,27 @@ export default function DashboardRequestActions({
             </Button>
           </Stack>
 
-          <Stack>
-            <Button variant="contained" sx={{ marginLeft: 3 }} onClick={approveOnboarding}>
-              {t('onboardingRequestPage.actions.approveButton')}
-            </Button>
-          </Stack>
+          {isGPU ? (
+            <Stack direction={'row'}>
+              <Button
+                variant="naked"
+                sx={{ marginLeft: 3 }}
+                startIcon={<FileDownloadIcon />}
+                onClick={downloadAttachment}
+              >
+                {t('onboardingRequestPage.actions.downloadButton')}
+              </Button>
+              <Button variant="contained" sx={{ marginLeft: 3 }} onClick={approveOnboarding}>
+                {t('onboardingRequestPage.actions.approveButton')}
+              </Button>
+            </Stack>
+          ) : (
+            <Stack>
+              <Button variant="contained" sx={{ marginLeft: 3 }} onClick={approveOnboarding}>
+                {t('onboardingRequestPage.actions.approveButton')}
+              </Button>
+            </Stack>
+          )}
         </Stack>
       )}
 

--- a/src/pages/dashboardRequest/components/__tests__/DashboardRequestActions.test.tsx
+++ b/src/pages/dashboardRequest/components/__tests__/DashboardRequestActions.test.tsx
@@ -4,6 +4,9 @@ import { renderWithProviders } from '../../../../utils/test-utils';
 import DashboardRequestActions from '../DashboardRequestActions';
 import { mockedOnboardingRequests } from '../../../../services/__mocks__/onboardingRequestService';
 import { productId2ProductTitle } from '@pagopa/selfcare-common-frontend/lib/utils/productId2ProductTitle';
+import { OnboardingApi } from '../../../../api/OnboardingApiClient';
+
+const originalFetch = global.fetch;
 
 const oldWindowLocation = global.window.location;
 const mockedLocation = {
@@ -20,6 +23,9 @@ beforeAll(() => {
 afterAll(() => {
   Object.defineProperty(window, 'location', { value: oldWindowLocation });
 });
+afterEach(() => {
+  global.fetch = originalFetch;
+});
 
 test('Test: Landing in an APPROVED onboarding request and click the close button', async () => {
   await renderWithProviders(
@@ -30,6 +36,7 @@ test('Test: Landing in an APPROVED onboarding request and click the close button
       setShowConfirmPage={() => {}}
       setShowRejectPage={() => {}}
       isToBeValidatedRequest={mockedOnboardingRequests[1].status === 'TOBEVALIDATED'}
+      isGPU={false}
     />
   );
 
@@ -40,8 +47,10 @@ test('Test: Landing in an APPROVED onboarding request and click the close button
   expect(declineBtn).not.toBeInTheDocument();
 });
 
-test('Test: Landing in an onboarding request with status TOBEVALIDATED and APPROVE it', async () => {
+test('Test: Landing in an onboarding request with status TOBEVALIDATED and APPROVE it with success API request', async () => {
   const setShowConfirmPage = jest.fn();
+  const mockedApproveOnboardingPspRequest = jest.spyOn(OnboardingApi, 'approveOnboardingRequest');
+  mockedApproveOnboardingPspRequest.mockResolvedValueOnce(mockedOnboardingRequests[0]);
 
   await renderWithProviders(
     <DashboardRequestActions
@@ -51,23 +60,50 @@ test('Test: Landing in an onboarding request with status TOBEVALIDATED and APPRO
       setShowConfirmPage={setShowConfirmPage}
       setShowRejectPage={() => {}}
       isToBeValidatedRequest={mockedOnboardingRequests[0].status === 'TOBEVALIDATED'}
+      isGPU={false}
     />
   );
 
   const approveBtn = screen.getByText('Approva');
   const declineBtn = screen.getByText('Rifiuta');
-  const closeBtn = screen.queryByText('Chiudi');
 
   expect(approveBtn).toBeInTheDocument();
   expect(declineBtn).toBeInTheDocument();
 
   fireEvent.click(approveBtn);
-
-  // await waitFor(() => expect(setShowConfirmPage).toHaveBeenCalled());
 });
 
-test('Test: Landing in an onboarding request with status TOBEVALIDATED and REJECT it', async () => {
+test('Test: Landing in an onboarding request with status TOBEVALIDATED and APPROVE it, with API error', async () => {
+  const setShowConfirmPage = jest.fn();
+  global.fetch = jest.fn().mockImplementation(() => {
+    throw new Error('errore');
+  });
+
+  await renderWithProviders(
+    <DashboardRequestActions
+      retrieveTokenIdFromUrl={mockedOnboardingRequests[0].tokenId}
+      partyName={mockedOnboardingRequests[0].institutionInfo.name}
+      productTitle={productId2ProductTitle(mockedOnboardingRequests[0].productId)}
+      setShowConfirmPage={setShowConfirmPage}
+      setShowRejectPage={() => {}}
+      isToBeValidatedRequest={mockedOnboardingRequests[0].status === 'TOBEVALIDATED'}
+      isGPU={false}
+    />
+  );
+
+  const approveBtn = screen.getByText('Approva');
+  const declineBtn = screen.getByText('Rifiuta');
+
+  expect(approveBtn).toBeInTheDocument();
+  expect(declineBtn).toBeInTheDocument();
+
+  fireEvent.click(approveBtn);
+});
+
+test('Test: Landing in an onboarding request with status TOBEVALIDATED and REJECT it API request', async () => {
   const setShowRejectPage = jest.fn();
+  const mockedRejectOnboardingPspRequest = jest.spyOn(OnboardingApi, 'rejectOnboardingRequest');
+  mockedRejectOnboardingPspRequest.mockResolvedValueOnce(mockedOnboardingRequests[2]);
 
   await renderWithProviders(
     <DashboardRequestActions
@@ -77,6 +113,7 @@ test('Test: Landing in an onboarding request with status TOBEVALIDATED and REJEC
       setShowConfirmPage={() => {}}
       setShowRejectPage={setShowRejectPage}
       isToBeValidatedRequest={mockedOnboardingRequests[0].status === 'TOBEVALIDATED'}
+      isGPU={false}
     />
   );
 
@@ -113,6 +150,93 @@ test('Test: Landing in an onboarding request with status TOBEVALIDATED and REJEC
   */
 });
 
+test('Test: Landing in an onboarding request with status TOBEVALIDATED and REJECT it with API error', async () => {
+  const setShowRejectPage = jest.fn();
+  global.fetch = jest.fn().mockImplementation(() => {
+    throw new Error('errore');
+  });
+
+  await renderWithProviders(
+    <DashboardRequestActions
+      retrieveTokenIdFromUrl={mockedOnboardingRequests[0].tokenId}
+      partyName={mockedOnboardingRequests[0].institutionInfo.name}
+      productTitle={productId2ProductTitle(mockedOnboardingRequests[0].productId)}
+      setShowConfirmPage={() => {}}
+      setShowRejectPage={setShowRejectPage}
+      isToBeValidatedRequest={mockedOnboardingRequests[0].status === 'TOBEVALIDATED'}
+      isGPU={false}
+    />
+  );
+
+  const approveBtn = screen.getByText('Approva');
+  const declineBtn = screen.getByText('Rifiuta');
+
+  expect(approveBtn).toBeInTheDocument();
+  expect(declineBtn).toBeInTheDocument();
+
+  fireEvent.click(declineBtn);
+});
+
+test('Test: Landing in an onboarding request with status TOBEVALIDATED and DOWNLOAD the resource, with success API request', async () => {
+  const setShowRejectPage = jest.fn();
+  const mockedDownloadOnboardingAttachments = jest.spyOn(
+    OnboardingApi,
+    'downloadOnboardingAttachments'
+  );
+  mockedDownloadOnboardingAttachments.mockResolvedValueOnce(mockedOnboardingRequests[7]);
+
+  await renderWithProviders(
+    <DashboardRequestActions
+      retrieveTokenIdFromUrl={mockedOnboardingRequests[7].tokenId}
+      partyName={mockedOnboardingRequests[7].institutionInfo.name}
+      productTitle={productId2ProductTitle(mockedOnboardingRequests[7].productId)}
+      setShowConfirmPage={() => {}}
+      setShowRejectPage={setShowRejectPage}
+      isToBeValidatedRequest={mockedOnboardingRequests[7].status === 'TOBEVALIDATED'}
+      isGPU={true}
+    />
+  );
+
+  const approveBtn = screen.getByText('Approva');
+  const declineBtn = screen.getByText('Rifiuta');
+  const downloadBtn = screen.getByText('Scarica');
+
+  expect(approveBtn).toBeInTheDocument();
+  expect(declineBtn).toBeInTheDocument();
+  expect(downloadBtn).toBeInTheDocument();
+
+  fireEvent.click(downloadBtn);
+});
+
+test('Test: Landing in an onboarding request with status TOBEVALIDATED and REJECT it with API error', async () => {
+  const setShowRejectPage = jest.fn();
+  global.fetch = jest.fn().mockImplementation(() => {
+    throw new Error('errore');
+  });
+
+  await renderWithProviders(
+    <DashboardRequestActions
+      retrieveTokenIdFromUrl={mockedOnboardingRequests[7].tokenId}
+      partyName={mockedOnboardingRequests[7].institutionInfo.name}
+      productTitle={productId2ProductTitle(mockedOnboardingRequests[7].productId)}
+      setShowConfirmPage={() => {}}
+      setShowRejectPage={setShowRejectPage}
+      isToBeValidatedRequest={mockedOnboardingRequests[7].status === 'TOBEVALIDATED'}
+      isGPU={true}
+    />
+  );
+
+  const approveBtn = screen.getByText('Approva');
+  const declineBtn = screen.getByText('Rifiuta');
+  const downloadBtn = screen.getByText('Scarica');
+
+  expect(approveBtn).toBeInTheDocument();
+  expect(declineBtn).toBeInTheDocument();
+  expect(downloadBtn).toBeInTheDocument();
+
+  fireEvent.click(downloadBtn);
+});
+
 test('Test: Onboarding request with not found token scenario', async () => {
   await renderWithProviders(
     <DashboardRequestActions
@@ -120,6 +244,7 @@ test('Test: Onboarding request with not found token scenario', async () => {
       setShowConfirmPage={() => {}}
       setShowRejectPage={() => {}}
       isToBeValidatedRequest={false}
+      isGPU={false}
     />
   );
 

--- a/src/services/__mocks__/onboardingRequestService.ts
+++ b/src/services/__mocks__/onboardingRequestService.ts
@@ -366,6 +366,67 @@ export const mockedOnboardingRequests: Array<OnboardingRequestResource> = [
       },
     ],
   },
+  // TOBEVALIDATED on prod-pagopa with institutionType === GPU
+  {
+    tokenId: 'tokenId08',
+    productId: 'prod-pagopa',
+    status: 'TOBEVALIDATED',
+    institutionInfo: {
+      id: 'institutionId3',
+      name: 'Comune di Torino',
+      address: 'Via Del Piero, 10',
+      zipCode: '22335',
+      mailAddress: 'comune.torino@pecemail.com',
+      fiscalCode: '87693452678',
+      vatNumber: '93947658123',
+      additionalInformations: {
+        agentOfPublicService: true,
+        agentOfPublicServiceNote: 'agentOfPublicServiceNote',
+        belongRegulatedMarket: true,
+        regulatedMarketNote: 'regulatedMarketNote',
+        establishedByRegulatoryProvision: true,
+        establishedByRegulatoryProvisionNote: 'establishedByRegulatoryProvisionNote',
+        ipa: false,
+        ipaCode: '',
+        otherNote: 'OtherNote',
+      },
+      pspData: undefined,
+      recipientCode: 'DummyRecipientCode03',
+      dpoData: {
+        address: 'Via Autonomia, 546',
+        pec: 'dpo03@pecdpo.com',
+        email: 'dpo03@dpo.com',
+      },
+      institutionType: 'GPU',
+      attachments: [
+        'dummy.pdf'
+      ]
+    },
+    manager: {
+      id: 'Manager03',
+      name: 'Manager03',
+      surname: 'Manager03',
+      fiscalCode: 'MNGMGR11D22B345K',
+      email: 'manager03@manager.com',
+    },
+    admins: [
+      // Use case with 2 admins
+      {
+        id: '7',
+        name: 'Admin07',
+        surname: 'Admin07',
+        fiscalCode: '77777777777',
+        email: 'admin07@comunedi.it',
+      },
+      {
+        id: '8',
+        name: 'Admin08',
+        surname: 'Admin08',
+        fiscalCode: '88888888888',
+        email: 'admin08@comunedi.it',
+      },
+    ],
+  },
 ];
 
 export const fetchOnboardingPspRequest = (tokenId: string): Promise<OnboardingRequestResource> => {

--- a/src/services/onboardingRequestService.ts
+++ b/src/services/onboardingRequestService.ts
@@ -48,3 +48,17 @@ export const approveOnboardingPspRequest = (
     return OnboardingApi.approveOnboardingRequest(tokenId);
   }
 };
+
+export const downloadOnboardingAttachments = (tokenId: string, name: string): Promise<OnboardingRequestResource> => {
+  /* istanbul ignore if */
+  if (process.env.REACT_APP_API_MOCK_REQUEST_DATA === 'true') {
+    const selectedOnboardingRequest = mockedOnboardingRequests.find((r) => r.tokenId === tokenId);
+    if (selectedOnboardingRequest) {
+      return new Promise((resolve) => resolve(selectedOnboardingRequest));
+    } else {
+      return Promise.reject('Onboarding request not found!');
+    }
+  } else {
+    return OnboardingApi.downloadOnboardingAttachments(tokenId, name);
+  }
+};

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -4,3 +4,8 @@
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
 import '../src/locale';
+
+beforeEach(() => {
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+});


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

[SELC-5516] feat: Added button to download the document
[SELC-5640] feat: Update the client open-api for the new institutionType GPU
[SELC-6154] feat: Upgrade the model of the v2/tokens/{onboardingId} 

#### Motivation and Context

This changes add the API call and the buttons that triggers it to download the request document of a new GPU that wants to onbaord himself

#### How Has This Been Tested?

- Tested that the new buttons triggers the new API
- Tested that with the new onboarding-open-api, the generated one, contains also the new institutionType GPU
- Tested with new junit test

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[SELC-5516]: https://pagopa.atlassian.net/browse/SELC-5516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SELC-5640]: https://pagopa.atlassian.net/browse/SELC-5640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SELC-6154]: https://pagopa.atlassian.net/browse/SELC-6154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ